### PR TITLE
Fix Tooltip style in Plank (elementary OS)

### DIFF
--- a/gtk-3.18/gtk.css
+++ b/gtk-3.18/gtk.css
@@ -2378,8 +2378,8 @@ GtkInfoBar {
       border-color: rgba(255, 255, 255, 0.2); }
 
 .tooltip {
-  color: #BAC3CF;
-  border-radius: 2px; }
+  color: #FFFFFF;
+  border-radius: 5px; }
   .tooltip.background {
     background-color: rgba(75, 81, 98, 0.95);
     background-clip: padding-box; }
@@ -2387,9 +2387,10 @@ GtkInfoBar {
     background-color: transparent; }
 
 .tooltip * {
-  padding: 4px;
   background-color: transparent;
-  color: inherit; }
+  color: inherit; 
+  text-shadow: 0 1px 2px alpha (#000, 0.6);
+}
 
 :selected GtkColorSwatch {
   box-shadow: none; }


### PR DESCRIPTION
Tooltip doesn't look nice in Plank, so I made this adjustment.

**Original**

![original](https://user-images.githubusercontent.com/11943860/29991484-2e6d80bc-8f5e-11e7-9ffa-1b85366d9c7d.png)

**Improved style**

![modified](https://user-images.githubusercontent.com/11943860/29991488-465b7d32-8f5e-11e7-81d2-3f537c3755ad.png)
